### PR TITLE
Fix copying stale data during refill

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ where
     fn refill(&mut self) -> Result<usize, io::Error> {
         let mut dat: [u8; MAX_SAMPLES_PER_FRAME * 5] = [0; MAX_SAMPLES_PER_FRAME * 5];
         let read_bytes = self.reader.read(&mut dat)?;
-        self.buffer.extend(dat.iter());
+        self.buffer.extend(dat[..read_bytes].iter());
 
         Ok(read_bytes)
     }


### PR DESCRIPTION
The refill code assumed the buffer would be filled completely on each read, causing stale data to be placed in the buffer near the EOF. Now only copies the amount of data that was actually read.