### PR TITLE
export minimp3-sys ffi ("pub extern crate")

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate minimp3_sys as ffi;
+pub extern crate minimp3_sys as ffi;
 extern crate slice_deque;
 
 use slice_deque::SliceDeque;


### PR DESCRIPTION
Simple change that allows people to use the sys crate as well as the safe wrapper, re-exporting dependencies is good.