### PR TITLE
Replaces slice_deque with slice_ring_buffer (maintained fork)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/germangb/minimp3-rs.git"
 edition = "2018"
 
 [dependencies]
-slice-deque = "0.3.0"
+slice-ring-buffer = "0.3.2"
 minimp3-sys = { version = "0.3", path = "minimp3-sys" }
 tokio = { version = "1.0", features = ["io-util"], optional = true }
 thiserror = "1.0.23"


### PR DESCRIPTION
Fixes: #29
