### PR TITLE
fixed : replace slice_deque with slice_ring_buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimp3"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["germän gômez <germangb42@gmail.com>", "Erin Moon <erin@hashbang.sh>"]
 description = "Rust bindings for the minimp3 library."
 keywords = ["mp3", "audio", "decoder", "mpeg", "media"]
@@ -10,7 +10,7 @@ repository = "https://github.com/germangb/minimp3-rs.git"
 edition = "2018"
 
 [dependencies]
-slice-deque = "0.3.0"
+slice-ring-buffer = "0.3.0"
 minimp3-sys = { version = "0.3", path = "minimp3-sys" }
 tokio = { version = "1.0", features = ["io-util"], optional = true }
 thiserror = "1.0.23"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 pub use error::Error;
 pub use minimp3_sys as ffi;
 
-use slice_deque::SliceDeque;
+use slice_ring_buffer::SliceRingBuffer;
 use std::{io, marker::Send, mem};
 
 mod error;
@@ -27,7 +27,7 @@ const REFILL_TRIGGER: usize = MAX_SAMPLES_PER_FRAME * 8;
 /// [`Frame`]: ./struct.Frame.html
 pub struct Decoder<R> {
     reader: R,
-    buffer: SliceDeque<u8>,
+    buffer: SliceRingBuffer<u8>,
     buffer_refill: Box<[u8; MAX_SAMPLES_PER_FRAME * 5]>,
     decoder: Box<ffi::mp3dec_t>,
 }
@@ -61,7 +61,7 @@ impl<R> Decoder<R> {
 
         Self {
             reader,
-            buffer: SliceDeque::with_capacity(BUFFER_SIZE),
+            buffer: SliceRingBuffer::with_capacity(BUFFER_SIZE),
             buffer_refill: Box::new([0; MAX_SAMPLES_PER_FRAME * 5]),
             decoder: minidec,
         }


### PR DESCRIPTION
Same as this pull request #43 but certain typos such as slice_ring_bufffer in the cargo.toml and SliceRingDeque instead of SliceRingBuffer were made because of which the crate was not building.
With this by directly using my fork in a project of mine i fixed issue #42 